### PR TITLE
implement OfferContext

### DIFF
--- a/front-end/src/context/OfferContext.jsx
+++ b/front-end/src/context/OfferContext.jsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useState } from 'react';
+import { mockOffers as initialIncoming } from '../utils/mockOffers';
+import { mockMyOffers as initialOutgoing } from '../utils/mockMyOffers';
+import { useItems } from './ItemContext';
+
+const OfferContext = createContext();
+
+export function OfferProvider({ children }) {
+  const [offers, setOffers] = useState(initialIncoming); // Offers received
+  const [myOffers, setMyOffers] = useState(initialOutgoing); // Offers you made
+
+  let itemTools;
+  try {
+    itemTools = useItems();
+  } catch {
+    itemTools = null;
+  }
+
+  // --- Incoming (ListingOffers) ---
+  const rejectOffer = (offerId) => {
+    setOffers((prev) => prev.filter((o) => o.id !== offerId));
+  };
+
+  const acceptOffer = (offerId, itemId) => {
+    setOffers((prev) =>
+      prev.map((o) => (o.id === offerId ? { ...o, status: 'Accepted' } : o))
+    );
+    itemTools?.markUnavailable?.(itemId, 'sold');
+  };
+
+  // --- Outgoing (MyOffers) ---
+  const addOffer = (newOffer) => {
+    setMyOffers((prev) => [newOffer, ...prev]);
+  };
+
+  const cancelMyOffer = (offerId, myItemId) => {
+    setMyOffers((prev) => prev.filter((o) => o.id !== offerId));
+    itemTools?.revertOfferStatus?.(myItemId);
+  };
+
+  const removeMyOffersByItemId = (myItemId) => {
+    setMyOffers((prev) => prev.filter((o) => o.myItemId !== myItemId));
+  };
+
+  return (
+    <OfferContext.Provider
+      value={{
+        offers,
+        rejectOffer,
+        acceptOffer,
+        myOffers,
+        addOffer,
+        cancelMyOffer,
+        removeMyOffersByItemId,
+      }}
+    >
+      {children}
+    </OfferContext.Provider>
+  );
+}
+
+export function useOffers() {
+  return useContext(OfferContext);
+}


### PR DESCRIPTION
- Added OfferContext with mock state for received and sent offers
- Integrated with ItemContext to update item availability on accept/cancel
- Implemented addOffer(), rejectOffer(), acceptOffer(), cancelMyOffer()
- Supports both ListingOffers (incoming) and MyOffers (outgoing) flows
- Ensures local state sync between items and offers

Closes #127, #154, #159, #160, #165, #208, #210, #215, #216