### PR TITLE
add ChatContext

### DIFF
--- a/front-end/src/context/ChatContext.jsx
+++ b/front-end/src/context/ChatContext.jsx
@@ -1,0 +1,66 @@
+import { createContext, useContext, useState } from 'react';
+import { mockChats as initialChats } from '../utils/mockChats';
+
+const ChatContext = createContext();
+
+export function ChatProvider({ children }) {
+  const [chats, setChats] = useState(initialChats);
+
+  // Helper to get a readable time string
+  const timeNow = () => {
+    const date = new Date();
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  // Find or create a chat by username (no duplicates)
+  const getOrCreateChat = (username) => {
+    let chat = chats.find((c) => c.user === username);
+    if (!chat) {
+      chat = {
+        id: chats.length + 1,
+        user: username,
+        lastMessage: 'New conversation started',
+        time: timeNow(),
+        messages: [
+          { sender: 'me', text: 'Hey there!', time: timeNow() },
+          { sender: username, text: 'Hi! Nice to connect.', time: timeNow() },
+        ],
+      };
+      setChats((prev) => {
+        // prevent duplicates just in case
+        if (prev.find((c) => c.user === username)) return prev;
+        return [...prev, chat];
+      });
+    }
+    return chat;
+  };
+
+  // Add a message to an existing chat
+  const addMessage = (username, messageText) => {
+    setChats((prev) =>
+      prev.map((chat) =>
+        chat.user === username
+          ? {
+              ...chat,
+              lastMessage: messageText,
+              time: timeNow(),
+              messages: [
+                ...chat.messages,
+                { sender: 'me', text: messageText, time: timeNow() },
+              ],
+            }
+          : chat
+      )
+    );
+  };
+
+  return (
+    <ChatContext.Provider value={{ chats, getOrCreateChat, addMessage }}>
+      {children}
+    </ChatContext.Provider>
+  );
+}
+
+export function useChat() {
+  return useContext(ChatContext);
+}


### PR DESCRIPTION
Append message to local conversation mock — closes #168
Define message object structure (sender, text, time) — closes #169
Define chat history structure (chat list + messages) — closes #191
Decide structure for mock chat list — refs #180
Display timestamp for each message — refs #187
Simulate sender/receiver IDs via 'me' vs username — refs #171