### PR TITLE
Add listings service tests covering item creation rules and visibility

### DIFF
--- a/back-end/tests/listings.test.js
+++ b/back-end/tests/listings.test.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { addItemForUser, listPublicListings } from '../src/services/app-service.js';
+import { store, setCurrentUser, getCurrentUser } from '../src/data/mockStore.js';
+import { mockUsers } from '../src/data/mockUsers.js';
+import { mockItems } from '../src/data/mockItems.js';
+import { mockOffers } from '../src/data/mockOffers.js';
+import { mockChats } from '../src/data/mockChats.js';
+
+const clone = (data) => JSON.parse(JSON.stringify(data));
+const resetStore = () => {
+  store.users = clone(mockUsers);
+  store.items = clone(mockItems);
+  store.offers = clone(mockOffers);
+  store.chats = clone(mockChats);
+  store.currentUser = store.users[0]?.username || null;
+};
+
+describe('Item creation', () => {
+  beforeEach(() => resetStore());
+
+  // Friendly reminder that a title is required when I add something new
+  it('reminds me to name my item before saving', () => {
+    const user = getCurrentUser();
+    expect(() => addItemForUser(user, { title: '' })).to.throw('Title is required');
+  });
+
+  // Checks that new private gear belongs to me and stays hidden from explore feed
+  it('adds my private item without showing it to everyone yet', () => {
+    const user = getCurrentUser();
+    const added = addItemForUser(user, { title: 'Gaming Chair', category: 'Furniture' });
+    expect(added.ownerUsername).to.equal(user.username);
+    expect(added.status).to.equal('private');
+
+    const publicListings = listPublicListings({}, user.username);
+    expect(publicListings.some((item) => item.id === added.id)).to.equal(false);
+  });
+
+  // Ensures swapping accounts changes which items get filtered out
+  it('respects whichever account is currently active', () => {
+    const other = store.users[2];
+    setCurrentUser(other.username);
+    const listings = listPublicListings({}, other.username);
+    expect(listings.every((item) => item.ownerUsername !== other.username)).to.equal(true);
+  });
+});


### PR DESCRIPTION
closes:
Task t[#293 Write unit tests for authentication routes (Mocha + Chai)]
Task t[#294 Write unit tests for item and offer routes (Mocha + Chai)]
Task t[#295 Write unit tests for messages and profile routes (Mocha + Chai)]
Task t[#296 Verify minimum 50 % code coverage with c8]