### PR TITLE
Itemstest

### DIFF
--- a/back-end/tests/items.test.js
+++ b/back-end/tests/items.test.js
@@ -17,14 +17,10 @@ const resetStore = () => {
 
 describe('Item creation', () => {
   beforeEach(() => resetStore());
-
-  // Friendly reminder that a title is required when I add something new
   it('reminds me to name my item before saving', () => {
     const user = getCurrentUser();
     expect(() => addItemForUser(user, { title: '' })).to.throw('Title is required');
   });
-
-  // Checks that new private gear belongs to me and stays hidden from explore feed
   it('adds my private item without showing it to everyone yet', () => {
     const user = getCurrentUser();
     const added = addItemForUser(user, { title: 'Gaming Chair', category: 'Furniture' });
@@ -34,8 +30,6 @@ describe('Item creation', () => {
     const publicListings = listPublicListings({}, user.username);
     expect(publicListings.some((item) => item.id === added.id)).to.equal(false);
   });
-
-  // Ensures swapping accounts changes which items get filtered out
   it('respects whichever account is currently active', () => {
     const other = store.users[2];
     setCurrentUser(other.username);


### PR DESCRIPTION
Description:

Adds unit tests for item creation and listing behavior:
Validates title is required when creating an item.
Confirms newly added items are private by default and not included in public listings.
Ensures functions respect the currently active user context.
Tests target service-level behavior (addItemForUser, listPublicListings) against the mock store.
Related issues:

[https://github.com/agile-students-fall2025/4-final-swapbay/issues/286]
[https://github.com/agile-students-fall2025/4-final-swapbay/issues/287]
[https://github.com/agile-students-fall2025/4-final-swapbay/issues/288]
[https://github.com/agile-students-fall2025/4-final-swapbay/issues/294]