### PR TITLE
updated header

### DIFF
--- a/front-end/src/components/Header.jsx
+++ b/front-end/src/components/Header.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useChat } from '../context/ChatContext';
 
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
   const { logout, user } = useAuth();
+  const { unreadTotal } = useChat();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -35,14 +37,21 @@ export default function Header() {
         {/* Desktop Navigation */}
         <ul className="hidden md:flex space-x-8 text-gray-700 font-medium items-center">
           {navLinks.map((link) => (
-            <li key={link.path}>
+            <li key={link.path} className="relative">
               <Link
                 to={link.path}
                 className={`hover:text-blue-600 transition ${
                   location.pathname === link.path ? 'text-blue-600' : ''
                 }`}
               >
-                {link.name}
+                <span className="relative inline-flex items-center">
+                  {link.name}
+                  {link.name === 'Messages' && unreadTotal > 0 && (
+                    <span className="absolute -top-2 -right-3 h-5 min-w-[20px] px-1 rounded-full bg-red-500 text-white text-[11px] leading-5 text-center">
+                      {unreadTotal > 9 ? '9+' : unreadTotal}
+                    </span>
+                  )}
+                </span>
               </Link>
             </li>
           ))}
@@ -82,13 +91,20 @@ export default function Header() {
       {menuOpen && (
         <ul className="md:hidden bg-white border-t text-gray-700 font-medium">
           {navLinks.map((link) => (
-            <li key={link.path}>
+            <li key={link.path} className="relative">
               <Link
                 to={link.path}
                 className="block p-3 border-b hover:bg-gray-100"
                 onClick={() => setMenuOpen(false)}
               >
-                {link.name}
+                <span className="relative inline-flex items-center">
+                  {link.name}
+                  {link.name === 'Messages' && unreadTotal > 0 && (
+                    <span className="ml-2 inline-flex items-center justify-center h-5 min-w-[20px] px-1 rounded-full bg-red-500 text-white text-[11px]">
+                      {unreadTotal > 9 ? '9+' : unreadTotal}
+                    </span>
+                  )}
+                </span>
               </Link>
             </li>
           ))}


### PR DESCRIPTION
This pull request updates the `Header` component to visually indicate the number of unread chat messages in the navigation bar. The unread message badge is shown both in the desktop and mobile navigation menus, improving user awareness of new messages.

**User interface enhancements:**

* Added a red unread messages badge to the "Messages" navigation link in both desktop and mobile menus, displaying the count of unread messages (capped at "9+"). [[1]](diffhunk://#diff-16f0ab07feaac685a8c5aa6fda26422741b6e138d02bd452fbb1f908bfa1c6c7L38-R54) [[2]](diffhunk://#diff-16f0ab07feaac685a8c5aa6fda26422741b6e138d02bd452fbb1f908bfa1c6c7L85-R107)

**Integration with chat context:**

* Imported and used `unreadTotal` from `ChatContext` to dynamically display the unread message count in the navigation.